### PR TITLE
Modified host regex to match alternative syntax

### DIFF
--- a/install/etc/cont-init.d/10-cloudflare-companion
+++ b/install/etc/cont-init.d/10-cloudflare-companion
@@ -63,7 +63,7 @@ def check_container(c):
             value = c.attrs.get(u'Config').get(u'Labels').get(prop)
             if 'Host' in value:
                 print "container rule value: ", value
-                extracted_domains = re.findall(r'Host.*?\(\`(.*?)\`\)', value)
+                extracted_domains = re.findall(r'\`([a-zA-Z0-9\.]+)\`', value)
                 print "extracted_domains from rule: ", extracted_domains
                 cont_id = c.attrs.get(u'Id')
                 if len(extracted_domains) > 1:


### PR DESCRIPTION
The following host rule syntax is valid within traefik:

"Host(`subdomain.domain.com`,`subdomain2.domain.com`,`subdomain3.domain.com`)"

This configuration was incorrectly parsed previously, and the 'Host' portion
of regex is safe to remove based on the "if 'Host' in value:" check.